### PR TITLE
Enable dependabot for cargo and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
`Dependabot` is a tool provided by `Github`, it helps keeping the dependencies up to date.
Every time it detects that one of the dependencies has a new version, it opens a PR with the version bump.

In this pr, we enable the dependabot on `cargo` and `github-actions`

Details about the tool and how to configure it: https://docs.github.com/en/code-security/dependabot