### PR TITLE
Add new integration 400 Bad Request test for event endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ struct State {
 }
 
 pub fn run() -> Result<Server, std::io::Error> {
-    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("info"));
     let conn = Connection::open_in_memory().unwrap();
 
     conn.execute(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use rustls::{Certificate, PrivateKey, ServerConfig};
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::{fs::File, io::BufReader};
 
@@ -37,7 +38,7 @@ struct State {
     conn: Arc<Mutex<Connection>>,
 }
 
-pub fn run() -> Result<Server, std::io::Error> {
+pub fn run(tcp_listener: TcpListener) -> Result<Server, std::io::Error> {
     let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("info"));
     let conn = Connection::open_in_memory().unwrap();
 
@@ -95,9 +96,9 @@ pub fn run() -> Result<Server, std::io::Error> {
     });
 
     if env::var("CALENDAR_IS_PROD_ENV").is_ok() {
-        server = server.bind_rustls_021("0.0.0.0:8080", load_rustls_config())?;
+        server = server.listen_rustls_0_21(tcp_listener, load_rustls_config())?;
     } else {
-        server = server.bind(("0.0.0.0", 8080))?;
+        server = server.listen(tcp_listener)?;
     }
 
     Ok(server.run())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use calendar_backend::run;
+use std::net::TcpListener;
 
 #[actix_web::main]
 async fn main() -> Result<(), std::io::Error> {
-    run()?.await
+    let listener = TcpListener::bind("0.0.0.0:8080").expect("Failed to bind to port 8080");
+    run(listener)?.await
 }

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -26,6 +26,47 @@ async fn create_event_works() {
     assert_eq!(Some(0), response.content_length());
 }
 
+#[tokio::test]
+async fn create_event_missing_fields_return_400_bad_request() {
+    // Arrange event without name
+    spawn_app();
+
+    let event = serde_json::json!({
+        "username": "djacota",
+        "calendar_id": "djacota",
+        "date_time": "09-05-2023"
+    });
+
+    // Act
+    let response = reqwest::Client::new()
+        .post("http://127.0.0.1:8080/event")
+        .json(&event)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(400, response.status().as_u16());
+
+    // Arrange event without date_time
+    let event = serde_json::json!({
+        "username": "djacota",
+        "name": "add_bad_request_test",
+        "calendar_id": "djacota"
+    });
+
+    // Act
+    let response = reqwest::Client::new()
+        .post("http://127.0.0.1:8080/event")
+        .json(&event)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(400, response.status().as_u16());
+}
+
 // launch the server as a background task
 fn spawn_app() {
     let server = run().expect("Failed to bind address");


### PR DESCRIPTION
- add the integration test
- change the env_logger::init_from_env function to try_init_from_env. The old function panics if it is called more than once, thing that happens when we run multiple tests. The new method will return an error which will be ignored

- before this task the binding to the port was handled in run() method
  by the HttpServer. The problem appears when we want to run multiple
  tests in paralel which will need to have servers at different
  addresses
- for this, we moved the binding to the port outside of the run()
  method by creating a TcpListener and passing it to the HttpServer
- the main method will use the same address as before (0.0.0.0:8080)
- for the tests the OS will assign a random empty port because we used
  the port 0 (address: "127.0.0.1:0")
- we retrieve the ports assigned by the OS and pass them to our tests