### PR TITLE
Basic authentication for /event endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,14 +378,18 @@ version = "0.1.0"
 dependencies = [
  "actix-cors",
  "actix-web",
+ "anyhow",
+ "base64",
  "env_logger",
  "log",
  "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pemfile",
+ "secrecy",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -1331,6 +1341,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1524,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
 ]
 
 [[package]]
@@ -1905,6 +1944,12 @@ dependencies = [
  "cfg-if",
  "windows-sys",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,7 @@ rustls-pemfile = "1.0.3"
 actix-cors = "0.6.4"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.32.0", features = ["macros"] }
-
-
+base64 = "0.21"
+secrecy = { version = "0.8" }
+anyhow = "1"
+thiserror = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,12 +146,7 @@ async fn create_event(
 
     let result = conn.execute(
         "INSERT INTO event (user_id, username, name, date_time) VALUES (?1, ?2, ?3, ?4)",
-        (
-            &user_id,
-            &event.username,
-            &event.name,
-            &event.date_time,
-        ),
+        (&user_id, &event.username, &event.name, &event.date_time),
     );
     match result {
         Ok(_) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,20 @@
 use actix_cors::Cors;
 use actix_web::dev::Server;
-use actix_web::http::header;
-use actix_web::{get, middleware::Logger, post, web, App, HttpResponse, HttpServer};
+use actix_web::http::header::{self, HeaderMap};
+use actix_web::http::StatusCode;
+use actix_web::{
+    get, middleware::Logger, post, web, App, HttpRequest, HttpResponse, HttpServer, ResponseError,
+};
+use anyhow::Context;
+use base64::Engine;
 use log::info;
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use rustls::{Certificate, PrivateKey, ServerConfig};
 use rustls_pemfile::{certs, pkcs8_private_keys};
+use secrecy::{ExposeSecret, Secret};
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::fmt::Debug;
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::{fs::File, io::BufReader};
@@ -36,6 +43,29 @@ struct State {
     conn: Arc<Mutex<Connection>>,
 }
 
+struct Credentials {
+    username: String,
+    password: Secret<String>,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CustomError {
+    #[error("Authentication failed")]
+    AuthError(#[source] anyhow::Error),
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
+}
+
+impl ResponseError for CustomError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            CustomError::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            // Return a 401 for auth errors
+            CustomError::AuthError(_) => StatusCode::UNAUTHORIZED,
+        }
+    }
+}
+
 pub fn run(tcp_listener: TcpListener) -> Result<Server, std::io::Error> {
     let _ = env_logger::try_init_from_env(env_logger::Env::new().default_filter_or("info"));
     let conn = Connection::open_in_memory().unwrap();
@@ -43,6 +73,7 @@ pub fn run(tcp_listener: TcpListener) -> Result<Server, std::io::Error> {
     conn.execute(
         "CREATE TABLE event (
             id          INTEGER PRIMARY KEY,
+            user_id     INTEGER NOT NULL,
             username    TEXT NOT NULL,
             name        TEXT NOT NULL,
             date_time   TEXT NOT NULL
@@ -54,7 +85,7 @@ pub fn run(tcp_listener: TcpListener) -> Result<Server, std::io::Error> {
     conn.execute(
         "CREATE TABLE user (
             id        INTEGER PRIMARY KEY,
-            username  TEXT NOT NULL,
+            username  TEXT NOT NULL UNIQUE,
             password  TEXT NOT NULL
         )",
         (),
@@ -102,13 +133,25 @@ pub fn run(tcp_listener: TcpListener) -> Result<Server, std::io::Error> {
 }
 
 #[post("/event")]
-async fn create_event(event: web::Json<Event>, state: web::Data<State>) -> HttpResponse {
+async fn create_event(
+    req: HttpRequest,
+    event: web::Json<Event>,
+    state: web::Data<State>,
+) -> Result<HttpResponse, CustomError> {
     let mut stmt_result = (&state).conn.lock().expect("failed to lock conn");
     let conn = &mut *stmt_result;
 
+    let credentials = basic_authentication(req.headers()).map_err(CustomError::AuthError)?;
+    let user_id = validate_credentials(credentials, conn).await?;
+
     let result = conn.execute(
-        "INSERT INTO event (username, name, date_time) VALUES (?1, ?2, ?3)",
-        (&event.username, &event.name, &event.date_time),
+        "INSERT INTO event (user_id, username, name, date_time) VALUES (?1, ?2, ?3, ?4)",
+        (
+            &user_id,
+            &event.username,
+            &event.name,
+            &event.date_time,
+        ),
     );
     match result {
         Ok(_) => {
@@ -116,10 +159,12 @@ async fn create_event(event: web::Json<Event>, state: web::Data<State>) -> HttpR
         }
         Err(e) => {
             info!("error inserting event: {}", e);
-            return HttpResponse::InternalServerError().finish();
+            return Err(CustomError::UnexpectedError(anyhow::anyhow!(
+                "Error when saving the event"
+            )));
         }
     }
-    HttpResponse::Created().finish()
+    Ok(HttpResponse::Created().finish())
 }
 
 #[get("/calendar/{username}")]
@@ -227,4 +272,59 @@ fn load_rustls_config() -> rustls::ServerConfig {
     }
 
     config.with_single_cert(cert_chain, keys.remove(0)).unwrap()
+}
+
+fn basic_authentication(headers: &HeaderMap) -> Result<Credentials, anyhow::Error> {
+    // The header value, if present, must be a valid UTF8 string
+    let header_value = headers
+        .get("Authorization")
+        .context("The 'Authorization' header was missing")?
+        .to_str()
+        .context("The 'Authorization' header was not a valid UTF8 string.")?;
+    let base64encoded_segment = header_value
+        .strip_prefix("Basic ")
+        .context("The authorization scheme was not 'Basic'.")?;
+    let decoded_bytes = base64::engine::general_purpose::STANDARD
+        .decode(base64encoded_segment)
+        .context("Failed to base64-decode 'Basic' credentials.")?;
+    let decoded_credentials = String::from_utf8(decoded_bytes)
+        .context("The decoded credential string is not valid UTF8.")?;
+    // Split into two segments, using ':' as delimiter
+    let mut credentials = decoded_credentials.splitn(2, ':');
+    let username = credentials
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("A username must be provided in 'Basic' auth."))?
+        .to_string();
+    let password = credentials
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("A password must be provided in 'Basic' auth."))?
+        .to_string();
+
+    Ok(Credentials {
+        username,
+        password: Secret::new(password),
+    })
+}
+
+async fn validate_credentials(
+    credentials: Credentials,
+    conn: &Connection,
+) -> Result<i64, CustomError> {
+    let mut stmt = conn
+        .prepare("SELECT id FROM user WHERE username = ?1 and password = ?2")
+        .unwrap();
+
+    let id: Option<i64> = stmt
+        .query_row(
+            &[
+                credentials.username.as_str(),
+                credentials.password.expose_secret().as_str(),
+            ],
+            |row| row.get(0),
+        )
+        .optional()
+        .unwrap();
+
+    return id
+        .ok_or_else(|| CustomError::AuthError(anyhow::anyhow!("Invalid username or password.")));
 }

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -3,20 +3,20 @@ use std::net::TcpListener;
 
 #[tokio::test]
 async fn create_event_works() {
-    // Arrange
+    // Arrange - create the user
     let address = spawn_app();
+    let username = "djacota";
+    let password = "password";
 
-    let client = reqwest::Client::new();
-    let event = serde_json::json!({
-        "username": "djacota",
-        "name": "write_integration_tests",
-        "date_time": "09-05-2023"
+    let user = serde_json::json!({
+        "username": username,
+        "password": password,
     });
 
     // Act
-    let response = client
-        .post(&format!("{}/event", &address))
-        .json(&event)
+    let response = reqwest::Client::new()
+        .post(&format!("{}/user", &address))
+        .json(&user)
         .send()
         .await
         .expect("Failed to execute request.");
@@ -24,13 +24,53 @@ async fn create_event_works() {
     // Assert
     assert!(response.status().is_success());
     assert_eq!(Some(0), response.content_length());
+
+    // Arrange - create an event for the user previously created
+    let event = serde_json::json!({
+        "username": "djacota",
+        "name": "write_integration_tests",
+        "date_time": "09-05-2023"
+    });
+
+    // Act
+    let response_event = reqwest::Client::new()
+        .post(&format!("{}/event", &address))
+        .basic_auth(username, Some(password))
+        .json(&event)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert!(response_event.status().is_success());
+    assert_eq!(Some(0), response_event.content_length());
 }
 
 #[tokio::test]
-async fn create_event_missing_fields_return_400_bad_request() {
-    // Arrange event without name
+async fn create_event_returns_400_when_fields_are_not_available() {
+    // Arrange - create the user
     let address = spawn_app();
+    let username = "djacota";
+    let password = "password";
 
+    let user = serde_json::json!({
+        "username": username,
+        "password": password,
+    });
+
+    // Act
+    let response = reqwest::Client::new()
+        .post(&format!("{}/user", &address))
+        .json(&user)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert!(response.status().is_success());
+    assert_eq!(Some(0), response.content_length());
+
+    // Arrange - event without name
     let event = serde_json::json!({
         "username": "djacota",
         "calendar_id": "djacota",
@@ -40,6 +80,7 @@ async fn create_event_missing_fields_return_400_bad_request() {
     // Act
     let response = reqwest::Client::new()
         .post(&format!("{}/event", &address))
+        .basic_auth(username, Some(password))
         .json(&event)
         .send()
         .await
@@ -65,6 +106,55 @@ async fn create_event_missing_fields_return_400_bad_request() {
 
     // Assert
     assert_eq!(400, response.status().as_u16());
+}
+
+#[tokio::test]
+async fn event_requests_missing_authorization_are_rejected() {
+    // Arrange
+    let address = spawn_app();
+
+    let event = serde_json::json!({
+        "username": "djacota",
+        "name": "implement_basic_authentication",
+        "calendar_id": "djacota",
+        "date_time": "09-05-2023"
+    });
+
+    // Act
+    let response = reqwest::Client::new()
+        .post(&format!("{}/event", &address))
+        .json(&event)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(401, response.status().as_u16());
+}
+
+#[tokio::test]
+async fn event_requests_with_invalid_credentials_are_rejected() {
+    // Arrange
+    let address = spawn_app();
+
+    let event = serde_json::json!({
+        "username": "djacota",
+        "name": "implement_basic_authentication",
+        "calendar_id": "djacota",
+        "date_time": "09-05-2023"
+    });
+
+    // Act
+    let response = reqwest::Client::new()
+        .post(&format!("{}/event", &address))
+        .basic_auth("username", Some("password"))
+        .json(&event)
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Assert
+    assert_eq!(401, response.status().as_u16());
 }
 
 // launch the server as a background task

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -73,7 +73,6 @@ async fn create_event_returns_400_when_fields_are_not_available() {
     // Arrange - event without name
     let event = serde_json::json!({
         "username": "djacota",
-        "calendar_id": "djacota",
         "date_time": "09-05-2023"
     });
 
@@ -93,7 +92,6 @@ async fn create_event_returns_400_when_fields_are_not_available() {
     let event = serde_json::json!({
         "username": "djacota",
         "name": "add_bad_request_test",
-        "calendar_id": "djacota"
     });
 
     // Act
@@ -116,7 +114,6 @@ async fn event_requests_missing_authorization_are_rejected() {
     let event = serde_json::json!({
         "username": "djacota",
         "name": "implement_basic_authentication",
-        "calendar_id": "djacota",
         "date_time": "09-05-2023"
     });
 
@@ -140,7 +137,6 @@ async fn event_requests_with_invalid_credentials_are_rejected() {
     let event = serde_json::json!({
         "username": "djacota",
         "name": "implement_basic_authentication",
-        "calendar_id": "djacota",
         "date_time": "09-05-2023"
     });
 


### PR DESCRIPTION
- add a CustomError enum which will be used to represent two types of
  errors: AuthError (which occurs at authorization) and UnexpectedError
- in method basic_authentication: retrieve the credentials from the Authorization header. If it is
  missing, return an AuthError
- in method validate_credentials: get the userId from the db for the credentials provided by the user.
  If no userId is retrieved, return an error because the user doesn't
  exist
- add the user_id in the event table which will be used to match the
  event to the user. The parameter username will be removed in another
  task
- add 2 integration tests, one for the case in which the user doesn't
  provide the credentials and one in which the credentials provided are
  invalid
- update the create_event_works() test to use valid credentials when an
  event is created