### PR TITLE
Add vercel origin to CORS allowed origins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ dependencies = [
  "base64",
  "env_logger",
  "log",
+ "regex",
  "reqwest",
  "rusqlite",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ base64 = "0.21"
 secrecy = { version = "0.8" }
 anyhow = "1"
 thiserror = "1"
+regex = "1.9.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use actix_web::{
 use anyhow::Context;
 use base64::Engine;
 use log::info;
+use regex::Regex;
 use rusqlite::{Connection, OptionalExtension};
 use rustls::{Certificate, PrivateKey, ServerConfig};
 use rustls_pemfile::{certs, pkcs8_private_keys};
@@ -18,7 +19,6 @@ use std::fmt::Debug;
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::{fs::File, io::BufReader};
-use regex::Regex;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Event {
@@ -101,7 +101,8 @@ pub fn run(tcp_listener: TcpListener) -> Result<Server, std::io::Error> {
 
     let mut server = HttpServer::new(move || {
         //defining this regex outside in order to avoid to recompile it on every request
-        let vercel_origin: Regex = Regex::new(r"^https://calendar-frontend-.*\.vercel\.app$").unwrap();
+        let vercel_origin: Regex =
+            Regex::new(r"^https://calendar-frontend-.*\.vercel\.app$").unwrap();
         let mut cors = Cors::default()
             .allowed_origin("https://calendar.aguzovatii.com")
             .allowed_origin_fn(move |origin, _req_head|{


### PR DESCRIPTION
Right now it's not possible to access the backend from vercel generated addresses (e.g.: https://calendar-frontend-git-basicauthentication-aguzovatii.vercel.app/).

In this pr we add Vercel origin in CORS allowed origins.